### PR TITLE
Allow ServiceProvider config to work with false values

### DIFF
--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -30,13 +30,13 @@ class ServiceProvider extends IlluminateServiceProvider
                 ->withContextProvider(new UnleashContextProvider())
                 ->withStrategies(...(new $strategyProvider())->getStrategies());
 
-            if (config('unleash.automatic_registration')) {
+            if (config('unleash.automatic_registration') !== null) {
                 $builder = $builder->withAutomaticRegistrationEnabled(config('unleash.automatic_registration'));
             }
-            if (config('unleash.metrics')) {
+            if (config('unleash.metrics') !== null) {
                 $builder = $builder->withMetricsEnabled(config('unleash.metrics'));
             }
-            if (config('unleash.cache.enabled')) {
+            if (config('unleash.cache.enabled') !== null) {
                 /** @var UnleashCacheHandlerInterface $cacheHandler */
                 $cacheHandler = config('unleash.cache.handler');
 
@@ -45,7 +45,7 @@ class ServiceProvider extends IlluminateServiceProvider
                     config('unleash.cache.ttl')
                 );
             }
-            if (config('unleash.api_key')) {
+            if (config('unleash.api_key') !== null) {
                 $builder = $builder->withHeader('Authorization', config('unleash.api_key'));
             }
 


### PR DESCRIPTION
Currently, if a config value is set to false, it won't be passed into the UnleashBuilder's `with*` methods, leaving them with their default values. This causes issues with `automatic_registration`, which defaults to true but can't be overridden to false,  giving us problems when mocking the `Unleash` facade.