### PR TITLE
Update builder config checks

### DIFF
--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -30,13 +30,13 @@ class ServiceProvider extends IlluminateServiceProvider
                 ->withContextProvider(new UnleashContextProvider())
                 ->withStrategies(...(new $strategyProvider())->getStrategies());
 
-            if (config('unleash.automatic_registration')) {
+            if (config('unleash.automatic_registration') !== null) {
                 $builder = $builder->withAutomaticRegistrationEnabled(config('unleash.automatic_registration'));
             }
-            if (config('unleash.metrics')) {
+            if (config('unleash.metrics') !== null) {
                 $builder = $builder->withMetricsEnabled(config('unleash.metrics'));
             }
-            if (config('unleash.cache.enabled')) {
+            if (config('unleash.cache.enabled') !== null) {
                 /** @var UnleashCacheHandlerInterface $cacheHandler */
                 $cacheHandler = config('unleash.cache.handler');
 
@@ -45,7 +45,7 @@ class ServiceProvider extends IlluminateServiceProvider
                     config('unleash.cache.ttl')
                 );
             }
-            if (config('unleash.api_key')) {
+            if (config('unleash.api_key') !== null) {
                 $builder = $builder->withHeader('Authorization', config('unleash.api_key'));
             }
 

--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -28,15 +28,11 @@ class ServiceProvider extends IlluminateServiceProvider
                 ->withAppUrl(config('unleash.url'))
                 ->withAppName(config('unleash.environment')) // Same as `withGitlabEnvironment(...)`
                 ->withContextProvider(new UnleashContextProvider())
-                ->withStrategies(...(new $strategyProvider())->getStrategies());
-
-            if (config('unleash.automatic_registration') !== null) {
-                $builder = $builder->withAutomaticRegistrationEnabled(config('unleash.automatic_registration'));
-            }
-            if (config('unleash.metrics') !== null) {
-                $builder = $builder->withMetricsEnabled(config('unleash.metrics'));
-            }
-            if (config('unleash.cache.enabled') !== null) {
+                ->withStrategies(...(new $strategyProvider())->getStrategies())
+                ->withAutomaticRegistrationEnabled(!! config('unleash.automatic_registration'))
+                ->withMetricsEnabled(!! config('unleash.metrics'));
+            
+            if (!! config('unleash.cache.enabled')) {
                 /** @var UnleashCacheHandlerInterface $cacheHandler */
                 $cacheHandler = config('unleash.cache.handler');
 
@@ -45,7 +41,7 @@ class ServiceProvider extends IlluminateServiceProvider
                     config('unleash.cache.ttl')
                 );
             }
-            if (config('unleash.api_key') !== null) {
+            if (!! config('unleash.api_key')) {
                 $builder = $builder->withHeader('Authorization', config('unleash.api_key'));
             }
 


### PR DESCRIPTION
Extension of the original PR #13, thanks @rneal-ck.

I decided to attach the `with` methods directly on the builder to avoid any config confusion. I've also updated the other checks to use the double not operator to cast any config values to bools when needed.