### PR TITLE
Allow newer versions of cache dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
         "illuminate/http": "^6|^7|^8|^9",
         "unleash/client": "^1.5",
         "symfony/cache": "^5.3",
-		"psr/cache": "^1.0",
-		"psr/simple-cache": "^1.0"
-	},
+	"psr/cache": "^1.0|^2.0|^3.0",
+	"psr/simple-cache": "^1.0|^2.0|^3.0"
+    },
     "autoload": {
         "psr-4": {
             "JWebb\\Unleash\\": "src/"


### PR DESCRIPTION
Allow version 2.x and 3.x for psr/cache and psr/simple-cache