### PR TITLE
Allow ContextProvider overwriting & support newer version of symfony/cache package

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ If the cache option is enabled, by default the component will use the Laravel Ca
 #### Setting up custom strategies
 To add your own strategy, you can override or create your own Strategies Provider. A `UnleashStrategiesProviderInterface` is included for convenience. Once your custom class is build, you should modify the `unleash.strategy_provider` config value.
 
+#### Overwriting default context provider
+If you want to send more context by default, you can overwrite the `UnleashContextProvider`. Make sure that your class implements the `Unleash\Client\ContextProvider\UnleashContextProvider` interface (to prevent confusion with the UnleashContextProvider in this package, an option would be to alias it). After that, change the config value of `unleash.context_provider` to your custom created class.
+
 ## Usage
 
 Checking individual features

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ UNLEASH_CACHE_TTL=30
 #### Setting up the Middleware
 The module comes bundled with middleware for you to perform a feature check on routes and/or controllers.
 ```php
-#/app/Http/Kernal.php
+#/app/Http/Kernel.php
 protected $routeMiddleware = [
     ...
     'feature' => \JWebb\Unleash\Middleware\CheckFeature::class,
@@ -64,7 +64,7 @@ protected $routeMiddleware = [
 ];
 ```
 
-Once added to your `Kernal.php` file, you can use this in any area where middleware is applicable.
+Once added to your `Kernel.php` file, you can use this in any area where middleware is applicable.
 As an example, you could use this in a controller.
 ```php
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "illuminate/support": "^6|^7|^8|^9",
         "illuminate/http": "^6|^7|^8|^9",
         "unleash/client": "^1.7",
-        "symfony/cache": "^5.3",
+        "symfony/cache": "^5.3|^6.1",
 	"psr/cache": "^1.0|^2.0|^3.0",
 	"psr/simple-cache": "^1.0|^2.0|^3.0"
     },

--- a/config/unleash.php
+++ b/config/unleash.php
@@ -110,4 +110,16 @@ return [
     */
 
     'strategy_provider' => JWebb\Unleash\Providers\UnleashStrategiesProvider::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Context Provider
+    |--------------------------------------------------------------------------
+    |
+    | The provider which handles and initializes the context, giving the option
+    | to sent more context, automatically.
+    |
+    */
+
+    'context_provider' => JWebb\Unleash\Providers\UnleashContextProvider::class,
 ];

--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace JWebb\Unleash\Providers;
 
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
 use JWebb\Unleash\Interfaces\UnleashCacheHandlerInterface;
@@ -22,12 +21,13 @@ class ServiceProvider extends IlluminateServiceProvider
 
         $this->app->singleton(Unleash::class, function ($app) {
             $strategyProvider = config('unleash.strategy_provider');
+            $contextProvider = config('unleash.context_provider');
 
             $builder = UnleashBuilder::create()
                 ->withInstanceId(config('unleash.instance_id'))
                 ->withAppUrl(config('unleash.url'))
                 ->withAppName(config('unleash.environment')) // Same as `withGitlabEnvironment(...)`
-                ->withContextProvider(new UnleashContextProvider())
+                ->withContextProvider(new $contextProvider())
                 ->withStrategies(...(new $strategyProvider())->getStrategies())
                 ->withAutomaticRegistrationEnabled(!! config('unleash.automatic_registration'))
                 ->withMetricsEnabled(!! config('unleash.metrics'));


### PR DESCRIPTION
- Allows newest version of psr/cache to be used (symfony/cache only supports up to v2 in symfony/cache v5)
- Adds the possibility to overwrite the default ContextProvider.
- Small typo fix in README.md

Possibly the older packages can be removed. Not sure which PHP versions you would like to have supported. Can I also request this is brought along in a new version tag?