### PR TITLE
Add docblock type annotations to Facade

### DIFF
--- a/src/Facades/Unleash.php
+++ b/src/Facades/Unleash.php
@@ -4,6 +4,14 @@ namespace JWebb\Unleash\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static array setClient(Unleash\Client\Unleash $client)
+ * @method static bool isEnabled(string $featureName, ?\Unleash\Client\Configuration\Context $context = null, bool $default = false)
+ * @method static array getFeatures(bool $onlyEnabled = false, ?\Unleash\Client\Configuration\Context $context = null)
+ * @method static \Unleash\Client\DTO\Variant getVariant(string $featureName, ?\Unleash\Client\Configuration\Context $context = null, ?\Unleash\Client\DTO\Variant $fallbackVariant = null)
+ * @method static void register()
+ * @method static void getRepository()
+ */
 class Unleash extends Facade
 {
     /**


### PR DESCRIPTION
In order to make static analysis tools understand magic methods in Facade I have added a docblock with type annotations. Laravel does this as well for its Facades.