### PR TITLE
Added HTTP client override configuration

### DIFF
--- a/config/unleash.php
+++ b/config/unleash.php
@@ -80,6 +80,7 @@ return [
     |
     | Unleash cache settings. This will cache any API object responses for the
     | duration of the TTL.
+    | The cache is used to prevent stressing the feature flag endpoint.
     |
     */
 
@@ -87,6 +88,26 @@ return [
         'enabled' => env('UNLEASH_CACHE_ENABLED', false),
         'ttl' => env('UNLEASH_CACHE_TTL', 30),
         'handler' => JWebb\Unleash\Cache\CacheHandler::class
+    ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | HTTP Client Override
+    |--------------------------------------------------------------------------
+    |
+    | HTTP Client configuration settings.
+    | Setting the timeout settings manually will break the connection to an
+    | unstable endpoint and fail early.
+    |
+    */
+
+    'http_client_override' => [
+        'enabled' => env('UNLEASH_HTTP_CLIENT_OVERRIDE', false),
+        'config' => [
+            'timeout' => env('UNLEASH_HTTP_TIMEOUT', 5),
+            'connect_timeout' => env('UNLEASH_HTTP_CONNECT_TIMEOUT', 5),
+        ]
     ],
 
     /*

--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace JWebb\Unleash\Providers;
 
+use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
 use JWebb\Unleash\Interfaces\UnleashCacheHandlerInterface;
@@ -31,7 +32,11 @@ class ServiceProvider extends IlluminateServiceProvider
                 ->withStrategies(...(new $strategyProvider())->getStrategies())
                 ->withAutomaticRegistrationEnabled(!! config('unleash.automatic_registration'))
                 ->withMetricsEnabled(!! config('unleash.metrics'));
-            
+
+            if (!! config('unleash.http_client_override.enabled')) {
+                $builder = $builder->withHttpClient(new Client(config('unleash.http_client_override.config')));
+            }
+
             if (!! config('unleash.cache.enabled')) {
                 /** @var UnleashCacheHandlerInterface $cacheHandler */
                 $cacheHandler = config('unleash.cache.handler');

--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -7,18 +7,17 @@ use Unleash\Client\DTO\Feature;
 use Unleash\Client\DTO\Variant;
 use Unleash\Client\Repository\UnleashRepository;
 use Unleash\Client\Unleash as UnleashClient;
-use Unleash\Client\Unleash as UnleashImplemtation;
 
-class Unleash implements UnleashImplemtation
+class Unleash implements UnleashClient
 {
     /**
-     * @var UnleashImplemtation
+     * @var UnleashClient
      */
     public UnleashClient $client;
 
     /**
      * Unleash constructor.
-     * @param  UnleashImplemtation  $client
+     * @param  UnleashClient  $client
      */
     public function __construct(UnleashClient $client)
     {


### PR DESCRIPTION
Ability to set a custom timeout on the HTTP client configuration. By default, this uses Guzzle.